### PR TITLE
Image/Color picking tools.

### DIFF
--- a/src/components/IFrameTraitBuilder.vue
+++ b/src/components/IFrameTraitBuilder.vue
@@ -31,7 +31,7 @@
           <v-btn icon v-bind="attrs" @click="newItem()"><v-icon>mdi-plus</v-icon></v-btn>
         </template>
         <v-card>
-          <v-toolbar dense color="pink darken-4" class="text-h6">Edit Trair</v-toolbar>
+          <v-toolbar dense color="pink darken-4" class="text-h6">Edit Trait</v-toolbar>
           <v-card-text>
             <v-row justify="space-around" align="center" class="mt-2">
               <v-col>

--- a/src/views/editors/Manufacturers.vue
+++ b/src/views/editors/Manufacturers.vue
@@ -93,21 +93,17 @@
                       />
                     </v-col>
                     <v-col>
-                      <v-text-field
+                      Light Color
+                      <v-color-picker
                         v-model="selected.light"
-                        persistent-hint
-                        hint="Hex"
-                        label="Light Color"
-                        :readonly="isCore(selected.id)"
+                        :disabled="isCore(selected.id)"
                       />
                     </v-col>
                     <v-col>
-                      <v-text-field
+                      Dark Color
+                      <v-color-picker
                         v-model="selected.dark"
-                        persistent-hint
-                        hint="Hex"
-                        label="Dark Color"
-                        :readonly="isCore(selected.id)"
+                        :disabled="isCore(selected.id)"
                       />
                     </v-col>
                     <v-col cols="12">
@@ -218,7 +214,7 @@ export default Vue.extend({
   data: () => ({
     panels: 0,
     core_manufacturers: manufacturers,
-    selected: null,
+    selected: null as any,
     importKey: '',
   }),
   computed: {
@@ -233,15 +229,34 @@ export default Vue.extend({
         ).values(),
       ]
     },
+    liteColorRaw:{
+      get() {
+        return this.selected.light;
+      },
+      set (v: any) {
+        this.selected.light = v['hex'];
+      }
+    },
+    darkColorRaw:{
+      get() {
+        return this.selected.dark;
+      },
+      set (v: any) {
+        this.selected.dark = v['hex'];
+      }
+    }
   },
   methods: {
     addNew() {
-      if (!this.lcp.manufacturers) this.$set(this.lcp, 'manufacturers', [])
-      else
-        this.lcp.manufacturers.push({
-          id: 'new',
-          name: 'New Manufacturer',
-        })
+      if (!this.lcp.manufacturers){
+        this.$set(this.lcp, 'manufacturers', [])
+      } 
+      this.lcp.manufacturers.push({
+        id: 'new',
+        name: 'New Manufacturer',
+        light: '#ff0000',
+        dark: '#ff0000'
+      })
     },
     itemsByMID(id: string, type: string) {
       if (!this.lcp[type]) return []

--- a/src/views/editors/Manufacturers.vue
+++ b/src/views/editors/Manufacturers.vue
@@ -91,6 +91,11 @@
                         label="Logo URL"
                         :readonly="isCore(selected.id)"
                       />
+                      <v-img
+                        :src="selected.logo_url"
+                        max-height="222"
+                        contain
+                      />
                     </v-col>
                     <v-col>
                       Light Color

--- a/src/views/editors/Manufacturers.vue
+++ b/src/views/editors/Manufacturers.vue
@@ -94,6 +94,7 @@
                       <v-img
                         :src="selected.logo_url"
                         max-height="222"
+                        max-width="450"
                         contain
                       />
                     </v-col>

--- a/src/views/editors/components/_FrameEditor.vue
+++ b/src/views/editors/components/_FrameEditor.vue
@@ -24,7 +24,7 @@
               v-model="license_level"
             />
           </v-col>
-          <v-col>
+          <v-col cols="3">
             <v-combobox
               v-model="mechtype"
               label="Mech Type"
@@ -35,7 +35,7 @@
               :items="mechTypes"
             />
           </v-col>
-          <v-col>
+          <v-col cols="7">
             <v-text-field label="Image URL" hide-details v-model="image_url" />
           </v-col>
           <v-col cols="2">
@@ -47,6 +47,27 @@
               dense
               v-model="y_pos"
             />
+          </v-col>
+          <v-col cols="4">
+            Image Preview
+            <v-img 
+              :src="image_url"
+              max-height="300"
+              contain
+            />
+          </v-col>
+          <v-col cols="8">
+            Banner Preview
+            <div style="height: 72px">
+              <div style="display: flex; min-height: 100%; position: relative; min-width: 100%">
+              <v-img 
+                :src="image_url"
+                max-height="100%"
+                :position="'top '+y_pos+'% left 0px'"
+                style="position:absolute; top: 0; right: 0; z-index: 9"
+              />
+              </div>
+            </div>
           </v-col>
         </v-row>
         <v-row>


### PR DESCRIPTION
**Manufacturer Editor**
- Made it so that adding a new manufacturer creates the initialized empty array while also adding the new entry (so that you don't have to click it twice).
- Added image preview area for logo URL
- Changed the light and dark hex text fields into vuetify color pickers.

**Mech Trait Editor**
- Fixed a small typo

**Frame Editor**
- Added fields that preview the selected frame image: both the whole image, and a preview Mech Banner.