### PR TITLE
Fix type for tags and counters

### DIFF
--- a/src/components/ICounterBuilder.vue
+++ b/src/components/ICounterBuilder.vue
@@ -89,12 +89,20 @@
 
 <script lang="ts">
 import Vue from 'vue'
+
+export interface counter {
+  id: string
+  name: string
+  default_value: number
+  min: number
+  max: number
+}
 export default Vue.extend({
   name: 'counter-builder',
   props: { item: { type: Object, required: true } },
   data: () => ({
     dialog: false,
-    counter: {},
+    counter: {} as counter,
     isEdit: false,
     editIndex: -1,
   }),
@@ -102,17 +110,29 @@ export default Vue.extend({
     submit() {
       if (!this.counter) return
       if (this.isEdit) {
-        this.$set(this.item.counters, this.editIndex, this.counter)
+        this.$set(this.item.counters, this.editIndex, {
+          id: this.counter.id as string,
+          name: this.counter.name as string,
+          default_value: +this.counter.default_value,
+          min: +this.counter.min,
+          max: +this.counter.max
+        })
       } else {
-        if (!this.item.counters) this.$set(this.item, 'counters', [])
-        this.item.counters.push(this.counter)
+        if (!this.item.counters) this.$set(this.item, 'counters', [] as counter[])
+        this.item.counters.push({
+          id: this.counter.id,
+          name: this.counter.name,
+          default_value: +this.counter.default_value,
+          min: +this.counter.min,
+          max: +this.counter.max
+        })
       }
       this.$set(this, 'counter', {})
       this.isEdit = false
       this.editIndex = -1
       this.dialog = false
     },
-    edit(counter: any, index: number) {
+    edit(counter: counter, index: number) {
       this.counter = JSON.parse(JSON.stringify(counter))
       this.isEdit = true
       this.editIndex = index

--- a/src/components/TagSelector.vue
+++ b/src/components/TagSelector.vue
@@ -64,14 +64,17 @@
 import Vue from 'vue'
 import { tags } from 'lancer-data'
 import TieredStatInput from './TieredStatInput.vue'
-
+export interface tag {
+  id: string
+  val: number
+}
 export default Vue.extend({
   name: 'tag-selector',
   props: { item: { type: Object, required: true }, npc: { type: Boolean } },
   components: { TieredStatInput },
   data: () => ({
     menu: false,
-    tag: {},
+    tag: {} as tag,
     isEdit: false,
     editIndex: -1,
   }),
@@ -85,17 +88,23 @@ export default Vue.extend({
     submit() {
       if (!this.tag) return
       if (this.isEdit) {
-        this.$set(this.item.tags, this.editIndex, this.tag)
+        this.$set(this.item.tags, this.editIndex, {
+          id: this.tag.id,
+          val: +this.tag.val
+        })
       } else {
         if (!this.item.tags) this.$set(this.item, 'tags', [])
-        this.item.tags.push(this.tag)
+        this.item.tags.push({
+          id: this.tag.id,
+          val: +this.tag.val
+        })
       }
       this.$set(this, 'tag', {})
       this.isEdit = false
       this.editIndex = -1
       this.menu = false
     },
-    edit(tag: any, index: number) {
+    edit(tag: tag, index: number) {
       this.tag = JSON.parse(JSON.stringify(tag))
       this.isEdit = true
       this.editIndex = index


### PR DESCRIPTION
As is, tags and counters output the incorrect type for `counter.default_value`, `counter.max`, `counter.min`, and `tag.val`.  They currently get output as strings instead of numbers.  This PR fixes that by strongly typing what gets stored and ensuring it gets converted.

In its current state, tags values don't seem to work  imported into compcon (if you try to set a tag of limited=2, you won't see 2 charges when you equip the system because the value is `"2"` instead of `2`)
  

I'm guessing there are other cases where strings are output instead of numbers, but I haven't run into them.  Hopefully this PR can show a strategy that work to ensure the JSON that gets created 

You can see here in the vue state that the min, max, default_value, and val values are strings instead of integers
<img width="423" alt="Screen Shot 2022-09-16 at 12 08 09 PM" src="https://user-images.githubusercontent.com/5826660/190682645-23e76a85-3877-4a9f-a4f1-6e7e709f0cc5.png">


This is what the state tree looks like after my changes, and the resulting JSON is correct
<img width="386" alt="Screen Shot 2022-09-16 at 12 05 13 PM" src="https://user-images.githubusercontent.com/5826660/190682128-e7bd2a8b-430c-4239-90a2-66c73b2e2e9e.png">
