### PR TITLE
Allow users to make variant frames for Long Rim/Wallflower/KTB licenses

### DIFF
--- a/src/views/editors/components/_FrameEditor.vue
+++ b/src/views/editors/components/_FrameEditor.vue
@@ -510,11 +510,43 @@ export default {
         y_pos: this.y_pos,
       };
       if (e.variant && e.variant !== e.name){
-        let parentFrame = e.license_id;
+        let parentFrame = undefined;
         if (this.availableFrames && this.availableFrames.length){
           parentFrame = this.availableFrames.find((x : any) => (x.name === e.variant));
         }
-        e.license_id = parentFrame.license_id;
+        if (!parentFrame){
+          switch (e.variant.toLowerCase()){
+            case "atlas":
+              e.license_id = "mf_atlas";
+              break;
+            case "kidd":
+              e.license_id = "mf_kidd";
+              break;
+            case "zheng":
+              e.license_id = "mf_zheng";
+              break;
+            case "kobold":
+              e.license_id = "mf_kobold";
+              break;
+            case "sunzi":
+              e.license_id = "mf_sunzi";
+              break;
+            case "lich":
+              e.license_id = "mf_lich";
+              break;
+            case "emperor":
+              e.license_id = "mf_emperor";
+              break;
+            case "white witch":
+              e.license_id = "mf_white_witch";
+              break;
+            case "gilgamesh":
+              e.license_id = "mf_gilgamesh";
+              break;
+            default:
+              break;
+          }
+        } else { e.license_id = parentFrame.license_id; }
       }
       for (const stat in e.stats) {
         if (!isNaN(Number(e.stats[stat])))


### PR DESCRIPTION
The LCP editor has no knowledge of frames it can't source directly from @massif/lancer-data (reasonable enough). Unfortunately, this means that variant frames can't auto-infer the correct license_id to use if the license they're trying to spin off isn't in that namespace. 

To counteract this, hardcode a list of the currently existing new licenses added in various supplements (the current pile is Long Rim, Wallflower, KTB, & OWS). This is not necessary for something like SSMR, for example, since only new _licenses_ need to be added here.

In a better world, I coded this so that the LCP editor allows you to just specify a license_id separately, but this is probably the best solution in terms of "making it simple for users to use without in-depth knowledge of LCP rules".

This solution just requires the user to type in the name (case-insensitive, I lower them all when checking the name) of the mech correctly into the Variant field, and it'll run it through a quick & dirty switch case statement. Simple patch but hopefully solves woes.