### PR TITLE
Don't override weapon statistics with the (un-used) default profile statblock

### DIFF
--- a/src/assets/enums.ts
+++ b/src/assets/enums.ts
@@ -93,6 +93,7 @@ const synergyLocations = [
   { value: 'bolster', title: 'Bolster Action modal' },
   { value: 'ram', title: 'Ram Action modal' },
   { value: 'grapple', title: 'Grapple Action modal' },
+  { value: 'brace', title: 'Brace Action modal' },
   { value: 'tech_attack', title: 'Tech Attack Action modal' },
   { value: 'quick_tech', title: 'Quick Tech Action modal' },
   { value: 'overcharge', title: 'Overcharge Action modal' },

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -453,10 +453,13 @@ export default {
       if (!this.lcp.weapons) return;
       //collapse single-profile weapons for clean export
       this.lcp.weapons.forEach((w: any) => {
+        /* Previous versions of the editor preferred to use data from the weapon's single profile, if any exists
+         * However, the current version of the editor has default profiles as uneditable, so we should always trust the basic stats instead
+         */
         if (w.profiles && w.profiles.length === 1) {
-          for (const key in w.profiles[0]) {
+          /*for (const key in w.profiles[0]) {
             if (w.profiles[0][key]) w[key] = w.profiles[0][key];
-          }
+          }*/
           delete w.profiles;
         }
       });


### PR DESCRIPTION
Previously, you had a weird issue where changing (for example) only the name of a weapon would not be saved when you tried to export - it'd be saved until that point, but exporting would mysterious reset the weapon's state. This is because a single profile on weapons is treated as a default profile, and uneditable, to cut down on unnecessary space in the LCP or weird views on COMP/CON. However, when exporting, the editor was preferring the name/stats of the potentially un-used 0th profile instead of using the base stats of the weapon. (I'm assuming other things call `getProfiles()`, which returns the base stats if `profiles` has 1 entry, but the export referenced `w.profiles[0]` directly)

This should fix that weird bug. Very minor change, but it is what it is. Not sure what exactly prompts profiles[0] to be populated in other cases (preventing this issue), Idenhou on discord said certain stats worked, no clue. Didn't think it was worth the time to debug what causes a reload when the behavior is wrong in either case.