### PR TITLE
Correctly fix the profile issue this time, allow for CBs to have multiple synergies

### DIFF
--- a/src/components/ISynergyBuilder.vue
+++ b/src/components/ISynergyBuilder.vue
@@ -188,6 +188,7 @@ export default {
       this.wt = [];
       this.ws = [];
       this.st = [];
+      this.isEdit = false;
     },
   },
 };

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -453,13 +453,11 @@ export default {
       if (!this.lcp.weapons) return;
       //collapse single-profile weapons for clean export
       this.lcp.weapons.forEach((w: any) => {
-        /* Previous versions of the editor preferred to use data from the weapon's single profile, if any exists
-         * However, the current version of the editor has default profiles as uneditable, so we should always trust the basic stats instead
-         */
         if (w.profiles && w.profiles.length === 1) {
-          /*for (const key in w.profiles[0]) {
+          for (const key in w.profiles[0]) {
+            if (key === "name") continue;
             if (w.profiles[0][key]) w[key] = w.profiles[0][key];
-          }*/
+          }
           delete w.profiles;
         }
       });
@@ -472,7 +470,6 @@ export default {
       let count = 0;
       for (const key in this.lcp) {
         if (!Array.isArray(this.lcp[key])) continue;
-        console.log(key);
         if (key.toLowerCase() === 'manufacturers') continue;
         this.lcp[key].forEach((item: any, index: number) => {
           count++;

--- a/src/views/editors/components/CoreBonus.vue
+++ b/src/views/editors/components/CoreBonus.vue
@@ -208,6 +208,7 @@ export default {
       this.counters = [];
       this.integrated = [];
       this.special_equipment = [];
+      this.isEdit = false;
     },
   },
 };

--- a/src/views/editors/components/_WeaponEditor.vue
+++ b/src/views/editors/components/_WeaponEditor.vue
@@ -328,7 +328,6 @@ export default {
       this.dialog = false;
     },
     edit(weapon: any): void {
-      console.log(weapon);
       this.id = weapon.id;
       this.name = weapon.name;
       this.license = weapon.license;


### PR DESCRIPTION
Weapon Profiles are now back to copying everything over, since it's the least invasive solution - EXCEPT the name. That's not copied from the profiles. I may go back to this in the future to reorganize how profile creation is handled, but this is a simple 'emergency' fix.