### PR TITLE
Misc. bugfixes/features

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "@mdi/font": "^7.1.96",
     "@tiptap/extension-text-align": "^2.0.0-beta.218",
     "@tiptap/extension-underline": "^2.0.0-beta.218",
+    "@tiptap/extension-text-style": "^2.0.0-beta.218",
+    "@tiptap/extension-color": "^2.0.0-beta.218",
     "@tiptap/pm": "^2.0.0-beta.217",
     "@tiptap/starter-kit": "^2.0.0-beta.217",
     "@tiptap/vue-3": "^2.0.0-beta.217",

--- a/src/components/IDeployableBuilder.vue
+++ b/src/components/IDeployableBuilder.vue
@@ -152,7 +152,7 @@
               <v-col>
                 <v-select
                   label="Size"
-                  :items="[0.5, 1, 2, 3, 4]"
+                  :items="[0, 0.5, 1, 2, 3, 4]"
                   hide-details
                   v-model="size"
                 />
@@ -349,7 +349,7 @@ export default {
   }),
   computed: {
     confirmOK(): boolean {
-      return !!this.name && !!this.type && !!this.detail && !!this.size;
+      return !!this.name && !!this.type && !!this.detail && (!!this.size || this.type == "Mine");
     },
   },
   methods: {
@@ -358,7 +358,7 @@ export default {
       this.dialog = true;
     },
     submit(): void {
-      const e = {
+      const tmp = {
         name: this.name,
         type: this.type,
         detail: this.detail,
@@ -386,6 +386,10 @@ export default {
         synergies: this.synergies,
         counters: this.counters,
       };
+
+      const {"size" : _, ...mine} = tmp;
+      const e = (this.type == "Mine" || this.size == 0) ? mine : tmp;
+
       if (this.isEdit) {
         this.item.deployables[this.editIndex] = e;
       } else {

--- a/src/components/RichTextEditor.vue
+++ b/src/components/RichTextEditor.vue
@@ -1,4 +1,93 @@
 <template>
+  <component :is="'style'">
+  code.horus {
+    font-size: 1.1em;
+    background-color: rgba(0, 0, 0, 0.7) !important;
+    box-shadow: none;
+    color: white;
+    font-style: normal;
+    letter-spacing: 0.05em;
+    border-radius: 0;
+  }
+
+  code.horus:hover {
+    background-color: black !important;
+    animation: distort 0.6s infinite;
+    text-transform: uppercase;
+    font-weight: bold;
+  }
+
+  .horus--subtle {
+    animation: distort-subtle 5s infinite;
+  }
+
+  @keyframes distort {
+    0% {
+      text-shadow: 2px 1px #ff00ff, -2px -3px #00ffff;
+      transform: translate(-1px, 1px) translate3D(-30px, 0px, 0) rotate(-0.1deg);
+      cursor: crosshair;
+    }
+    25% {
+      text-shadow: -2px -3px #ff00ff, 2px 1px #00ffff;
+      transform: translate(2px, 1px) translate3D(-30px, 0px, 0) rotate(-0.1deg);
+      cursor: cell;
+    }
+    50% {
+      text-shadow: 2px -1px #ff00ff, -4px 1px #00ffff;
+      transform: translate(-2px, 1px) translate3D(-30px, 0px, 0) rotate(-0.1deg);
+      cursor: col-resize;
+    }
+    75% {
+      text-shadow: -4px -1px #ff00ff, -2px -1px #00ffff;
+      transform: translate(3px, 1px) translate3D(-30px, 0px, 0) rotate(-0.1deg);
+      cursor: move;
+    }
+    100% {
+      text-shadow: -2px 0 #ff00ff, 2px -1px #00ffff;
+      transform: translate(-2px, 0) translate3D(-30px, 0px, 0) rotate(-0.1deg);
+      cursor: all-scroll;
+    }
+  }
+
+  @keyframes distort-subtle {
+    25% {
+      text-shadow: none;
+    }
+    26% {
+      text-shadow: 2px -1px #ff0000, -2px 3px #00ffff;
+    }
+    27% {
+      text-shadow: -2px -3px #ff0000, 2px 1px #00ffff;
+    }
+    28% {
+      text-shadow: 2px 1px #ff0000, -4px 1px #00ffff;
+    }
+    29% {
+      text-shadow: -4px 1px #ff0000, -2px -1px #00ffff;
+    }
+    30% {
+      text-shadow: none;
+    }
+    75% {
+      text-shadow: none;
+    }
+    76% {
+      text-shadow: -4px 1px #ff0000, -2px -1px #00ffff;
+    }
+    77% {
+      text-shadow: -2px -3px #ff0000, 2px 1px #00ffff;
+    }
+    78% {
+      text-shadow: 2px -1px #ff0000, -2px 3px #00ffff;
+    }
+    79% {
+      text-shadow: 2px 1px #ff0000, -4px 1px #00ffff;
+    }
+    80% {
+      text-shadow: none;
+    }
+  }
+  </component>
   <v-card>
     <v-card-title class="mt-n1 mb-n2">{{ title }}</v-card-title>
     <v-divider />
@@ -45,6 +134,23 @@
               :color="editor && editor.isActive('code') ? 'pink' : ''"
               @click="editor.chain().focus().toggleCode().run()"
               ><v-icon size="large" icon="mdi-code-braces" /></v-btn
+          ></v-col>
+          <v-spacer />
+          <v-col cols="auto" style="width: 45px !important"
+            ><v-btn
+              variant="text"
+              size="small"
+              :color="editor && editor.isActive({class : 'horus'}) ? 'cyan' : ''"
+              @click="editor.chain().focus().setCode().updateAttributes('code', {class : 'horus'}).run()"
+              ><v-icon size="large" icon="mdi-sawtooth-wave" /></v-btn
+          ></v-col>
+          <v-col cols="auto" style="width: 45px !important"
+            ><v-btn
+              variant="text"
+              size="small"
+              :color="editor && editor.isActive({class : 'horus--subtle'}) ? 'purple' : ''"
+              @click="editor.chain().focus().setColor('').updateAttributes('p', {class : 'horus--subtle'}).run()"
+              ><v-icon size="large" icon="mdi-sine-wave" /></v-btn
           ></v-col>
           <v-spacer />
           <v-col cols="auto" style="width: 45px !important"
@@ -348,8 +454,10 @@
 import StarterKit from '@tiptap/starter-kit';
 import Underline from '@tiptap/extension-underline';
 import TextAlign from '@tiptap/extension-text-align';
-import { Editor, EditorContent } from '@tiptap/vue-3';
-
+import { Editor, EditorContent} from '@tiptap/vue-3';
+import { Code } from "@tiptap/extension-code";
+import { TextStyle } from '@tiptap/extension-text-style';
+import { Color } from '@tiptap/extension-color';
 export default {
   components: {
     EditorContent,
@@ -388,17 +496,56 @@ export default {
   },
 
   mounted() {
+    const HorusCode = Code.extend({
+      addAttributes() {
+        return {
+          class: {
+            default: null,
+            // Take the attribute values
+            renderHTML: attributes => {
+              // … and return an object with HTML attributes.
+              return (attributes.class) ? {class: `${attributes.class}`} : ``
+            },
+          },
+          color: {
+            default: null,
+            // Take the attribute values
+            renderHTML: attributes => {
+              // … and return an object with HTML attributes.
+              return (attributes.color) ? {color: `${attributes.color}`} : ``
+            },
+          },
+        }
+      },
+    });
+    const HorusSpan = TextStyle.extend({
+      addAttributes() {
+        return {
+          class: {
+            default: `horus--subtle`,
+            // Take the attribute values
+            renderHTML: attributes => {
+              // … and return an object with HTML attributes.
+                return {class: `${attributes.class}`}
+              },
+            },
+          }
+      },
+  })
     this.editor = new Editor({
       extensions: [
         TextAlign.configure({
           types: ['heading', 'paragraph'],
         }),
+        Color,
         Underline,
         StarterKit.configure({
           heading: {
             levels: [1, 2, 3],
           },
         }),
+        HorusCode,
+        HorusSpan,
       ],
       content: this.modelValue,
       onUpdate: () => {

--- a/src/views/editors/components/_FrameEditor.vue
+++ b/src/views/editors/components/_FrameEditor.vue
@@ -65,18 +65,20 @@
                 />
               </v-col>
               <v-col cols="12" v-show="!!image_url">
-                Banner Preview
+                <p>Banner Preview</p>
                 <div style="height: 72px" class="bg-blue-grey-darken-4 rounded">
                   <div
                     :style="` display: flex;
                               min-height: 100%;
                               position: relative;
                               min-width: 100%;
+                              background-size: auto 1000px;
                               background-image: url('${image_url}');
                               background-position: left 80px top ${y_pos}%;`"
                   >
                   </div>
                 </div>
+                <small>COMP/CON clamps image height to ~1000px when rendering banners, depending on window width</small>
               </v-col>
             </v-row>
           </v-col>

--- a/src/views/editors/components/_FrameEditor.vue
+++ b/src/views/editors/components/_FrameEditor.vue
@@ -68,19 +68,13 @@
                 Banner Preview
                 <div style="height: 72px" class="bg-blue-grey-darken-4 rounded">
                   <div
-                    style="
-                      display: flex;
-                      min-height: 100%;
-                      position: relative;
-                      min-width: 100%;
-                    "
+                    :style="` display: flex;
+                              min-height: 100%;
+                              position: relative;
+                              min-width: 100%;
+                              background-image: url('${image_url}');
+                              background-position: left 80px top ${y_pos}%;`"
                   >
-                    <v-img
-                      :src="image_url"
-                      height="100%"
-                      :position="`top ${y_pos}% left 0px`"
-                      style="position: absolute; top: 0; right: 0; z-index: 9"
-                    />
                   </div>
                 </div>
               </v-col>

--- a/src/views/editors/components/_WeaponEditor.vue
+++ b/src/views/editors/components/_WeaponEditor.vue
@@ -380,7 +380,7 @@ export default {
       this.license = '';
       this.license_level = 1;
       this.description = '';
-      this.mount = 'Aux';
+      this.mount = 'Auxiliary';
       this.type = 'Melee';
       this.no_attack = false;
       this.no_mods = false;


### PR DESCRIPTION
[Disable requiring size for mines, and don't erroneously add a size to Mines exported](https://github.com/massif-press/cc-lcp-editor/commit/5c05e56e1ae3c63a33ae4f0bc0f2ff1d8287898f)

It will forgo saving size if the size is set to 0 and the type is a Mine. This does not allow for size 0 normal deployables, ONLY for "Mine" type things.

[Allow for using fancy Horus text in the LCP editor :)](https://github.com/massif-press/cc-lcp-editor/commit/170b14532aef30e07a2827ed27396226c6ddda1b)

Adds two little icons to the text editor, so they're embedded in every text entry instance in the LCP editor. The sawtooth wave is for HORUS codeblock formatting, and the sine wave is for HORUS 'subtle' text. No promises that the buttons are very intuitive, but they _should_ work. The only finicky part is really that neither of the buttons are toggles, they only _apply_ the formatting, so you'd need to delete them (or in the case of horus-code formatting, just toggle it away from code to clear the formatting) to reset it.


[Fix (?) banner preview for frame data](https://github.com/massif-press/cc-lcp-editor/pull/54/commits/3e04c4a141764611e2ba3c14b20d6cc1985ef2e8)

I'm honestly not sure wtf is up with the old code. It's just copy-pasted from CompCon's codebase, which is presumably working since it works fine on there - however, I did notice that CompCon's compiled _output_ css is different. The code is an image inside a div inside a div, and the LCP editor turns it into an image + a div together, inside a div. I ended up just copying what CompCon's version turns into, which uses background-image on the div for the banner, and that works much better. The x-position is a little funky but that's not relevant for the preview purposes, I believe.