### PR TITLE
"Specialty" frame option

### DIFF
--- a/src/views/editors/components/_FrameEditor.vue
+++ b/src/views/editors/components/_FrameEditor.vue
@@ -64,6 +64,9 @@
                   v-model="y_pos"
                 />
               </v-col>
+              <v-col style="height: 80px" v-b-tooltip.hover title="Use this option to hide the mech from the license and instead use the image information for the license header.">
+                <v-checkbox label="Specialty" v-model="specialty" />
+              </v-col>
               <v-col cols="12" v-show="!!image_url">
                 <p>Banner Preview</p>
                 <div style="height: 72px" class="bg-blue-grey-darken-4 rounded">
@@ -454,6 +457,7 @@ export default {
     },
     active: { actions: [], bonuses: [], synergies: [] },
     passive: { actions: [], bonuses: [], synergies: [] },
+    specialty: false,
     image_url: '',
     y_pos: 0,
     isEdit: false,
@@ -502,6 +506,7 @@ export default {
         stats: this.stats,
         traits: this.traits,
         core_system: cs,
+        specialty: this.specialty,
         image_url: this.image_url,
         y_pos: this.y_pos,
       };
@@ -574,6 +579,7 @@ export default {
         bonuses: frame.core_system.passive_bonuses,
         synergies: frame.core_system.passive_synergies,
       };
+      this.specialty = frame.specialty;
       this.image_url = frame.image_url;
       this.y_pos = Number(frame.y_pos);
       this.isEdit = true;
@@ -632,6 +638,7 @@ export default {
       };
       this.active = { actions: [], bonuses: [], synergies: [] };
       this.passive = { actions: [], bonuses: [], synergies: [] };
+      this.specialty = false;
       this.image_url = '';
       this.y_pos = 0;
       this.isEdit = false;


### PR DESCRIPTION
[Issue #39 ](https://github.com/massif-press/cc-lcp-editor/issues/39)

An example for how to add the "Specialty" flag to a frame to customize the license header using the frame image information.