### PR TITLE
Set default frame save target from 12 to 10

### DIFF
--- a/src/views/editors/components/_FrameEditor.vue
+++ b/src/views/editors/components/_FrameEditor.vue
@@ -441,7 +441,7 @@ export default {
       repcap: 6,
       sensor_range: 10,
       tech_attack: 0,
-      save: 12,
+      save: 10,
       speed: 4,
       sp: 6,
     },


### PR DESCRIPTION
This is to avoid frames who are left to standard stats to have significantly higher save targets than would be balanced See [Issue 66](https://github.com/massif-press/cc-lcp-editor/issues/66) for more information.